### PR TITLE
feat: add change account functionality

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -74,6 +74,17 @@ export const App: React.FC = () => {
       );
     }
 
+    if (appState.currentUseCase === 'change-account') {
+      return (
+        <AccountSelector 
+          onAccountSelected={(account) => {
+            handleAccountSelected(account);
+            setAppState(prev => ({ ...prev, currentUseCase: null }));
+          }}
+        />
+      );
+    }
+
     if ((appState.currentUseCase === 'create' && !showInstructions) || 
         (appState.currentUseCase === 'create-and-add' && !appState.createdRepository && !showInstructions)) {
       return (

--- a/src/components/UseCaseSelector.tsx
+++ b/src/components/UseCaseSelector.tsx
@@ -23,6 +23,10 @@ const useCaseItems = [
     value: 'create-and-add' as UseCase,
   },
   {
+    label: 'Change GitHub Account',
+    value: 'change-account' as UseCase,
+  },
+  {
     label: 'Configure Gemini API Key',
     value: 'configure-gemini' as UseCase,
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface CreateRepositoryInput {
   owner?: string; // For organization repos
 }
 
-export type UseCase = 'create' | 'add-to-teams' | 'create-and-add' | 'configure-gemini';
+export type UseCase = 'create' | 'add-to-teams' | 'create-and-add' | 'configure-gemini' | 'change-account';
 
 export interface AppState {
   authState: AuthState | null;


### PR DESCRIPTION
## Summary
- Add 'Change GitHub Account' option to the main use case menu
- Enable users to switch between different GitHub accounts without restarting the application

## Changes
- [x] Add 'change-account' use case type to TypeScript types
- [x] Add 'Change GitHub Account' menu option to UseCaseSelector component
- [x] Update App component to handle the account change flow
- [x] When selected, redirect to AccountSelector and reset the use case after selection

## Test plan
- [x] Start the application and select an account
- [x] From the main menu, select 'Change GitHub Account'
- [x] Verify that the account selection screen appears
- [x] Select a different account
- [x] Verify that the main menu appears with the new account displayed
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)