### PR TITLE
Hotfix: ESC key now properly exits repository selection screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-usecases",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/src/components/RepositorySelector.tsx
+++ b/src/components/RepositorySelector.tsx
@@ -85,8 +85,7 @@ export const RepositorySelector: React.FC<RepositorySelectorProps> = ({ account,
     } else if (key.downArrow && showSuggestions) {
       setSelectedIndex((prev) => (prev < repositories.length - 1 ? prev + 1 : 0));
     } else if (key.escape) {
-      setRepositories([]);
-      setSelectedIndex(0);
+      onCancel();
     } else if (key.tab && showSuggestions && repositories[selectedIndex]) {
       // Tab to complete the selected repository name
       setSearchQuery(repositories[selectedIndex].name);
@@ -134,7 +133,7 @@ export const RepositorySelector: React.FC<RepositorySelectorProps> = ({ account,
           </Box>
         ))}
         <Box marginTop={1}>
-          <Text dimColor>↑↓ Navigate • Enter: Select • Tab: Complete • Esc: Clear</Text>
+          <Text dimColor>↑↓ Navigate • Enter: Select • Tab: Complete • Esc: Cancel</Text>
         </Box>
       </Box>
     );


### PR DESCRIPTION
## Summary
- Fixed ESC key behavior in repository selection screen to properly exit instead of clearing search results
- Updated hint text from "Esc: Clear" to "Esc: Cancel" to reflect correct behavior
- Bumped version to 1.1.2

## Test plan
- [x] Navigate to repository selection screen
- [x] Press ESC key
- [x] Verify it returns to the main menu instead of clearing results
- [x] Verify other keyboard shortcuts still work (↑↓, Enter, Tab)

🤖 Generated with [Claude Code](https://claude.ai/code)